### PR TITLE
Add support for custom resource URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A [JSON API](http://jsonapi.org) Implementation for Go, to be used e.g. as serve
 - [Interfaces to implement](#interfaces-to-implement)
   - [Responder](#responder)
   - [EntityNamer](#entitynamer)
+  - [EntityPather](#entitypather)
   - [MarshalIdentifier](#marshalidentifier)
   - [UnmarshalIdentifier](#unmarshalidentifier)
   - [Marshalling with References to other structs](#marshalling-with-references-to-other-structs)
@@ -164,6 +165,27 @@ have to implement `GetName`
 ```go
 func (s UnicornPost) GetName() string {
 	return "unicorn-posts"
+}
+```
+
+### EntityPather
+```go
+type EntityPather interface {
+	GetPath() string
+}
+```
+
+EntityPather is an optional interface used to customize the path that is generated for resources.
+The resulting base URL will take the form `/{apiPrefix}/{path}/{id}`
+
+When not implemented the resource type name will be used. 
+This matches the [recommended url format](https://jsonapi.org/recommendations/#urls-resource-collections)
+The JSON:API specification however is agnostic about URL formats. 
+You may choose to implement the interface to change the resource type specific section of the path. 
+
+```go
+func (s UnicornPost) GetPath() string {
+	return "blog/unicornposts"
 }
 ```
 

--- a/api.go
+++ b/api.go
@@ -244,8 +244,14 @@ func (api *API) addResource(prototype jsonapi.MarshalIdentifier, source interfac
 		return info
 	}
 
+	// check if EntityPather interface is implemented and use that as path instead
+	path := name
+	if entityPather, ok := prototype.(jsonapi.EntityPather); ok {
+		path = strings.Trim(entityPather.GetPath(), "/")
+	}
+
 	prefix := strings.Trim(api.info.prefix, "/")
-	baseURL := "/" + name
+	baseURL := "/" + path
 	if prefix != "" {
 		baseURL = "/" + prefix + baseURL
 	}

--- a/api_entity_path_test.go
+++ b/api_entity_path_test.go
@@ -1,0 +1,151 @@
+package api2go
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+type SconeTaste struct {
+	ID    string `json:"-"`
+	Taste string `json:"taste"`
+}
+
+func (s SconeTaste) GetID() string {
+	return s.ID
+}
+
+func (s *SconeTaste) SetID(ID string) error {
+	s.ID = ID
+	return nil
+}
+
+func (s SconeTaste) GetName() string {
+	return "Scone-tastes"
+}
+
+func (s SconeTaste) GetPath() string {
+	//Leading and trailing slashes are not required. Including in test to make sure we don't end up with double slashes
+	return "/food/sconeTastes/"
+}
+
+type SconeResource struct{}
+
+func (s SconeResource) FindOne(ID string, req Request) (Responder, error) {
+	return &Response{Res: SconeTaste{ID: "blubb", Taste: "Very Bad"}}, nil
+}
+
+func (s SconeResource) FindAll(req Request) (Responder, error) {
+	return &Response{Res: []SconeTaste{
+		{
+			ID:    "1",
+			Taste: "Very Good",
+		},
+		{
+			ID:    "2",
+			Taste: "Very Bad",
+		},
+	}}, nil
+}
+
+func (s SconeResource) Create(obj interface{}, req Request) (Responder, error) {
+	e := obj.(SconeTaste)
+	e.ID = "newID"
+	return &Response{
+		Res:  e,
+		Code: http.StatusCreated,
+	}, nil
+}
+
+func (s SconeResource) Delete(ID string, req Request) (Responder, error) {
+	return &Response{
+		Res:  SconeTaste{ID: ID},
+		Code: http.StatusNoContent,
+	}, nil
+}
+
+func (s SconeResource) Update(obj interface{}, req Request) (Responder, error) {
+	return &Response{
+		Res:  obj,
+		Code: http.StatusNoContent,
+	}, nil
+}
+
+var _ = Describe("Test route renaming with EntityPather interface", func() {
+	var (
+		api  *API
+		rec  *httptest.ResponseRecorder
+		body *strings.Reader
+	)
+	BeforeEach(func() {
+		api = NewAPIWithRouting(testPrefix, NewStaticResolver(""), newTestRouter())
+		api.AddResource(SconeTaste{}, SconeResource{})
+		rec = httptest.NewRecorder()
+		body = strings.NewReader(`
+		{
+			"data": {
+				"attributes": {
+					"taste": "smells awful"
+				},
+				"id": "blubb",
+				"type": "Scone-tastes"
+			}
+		}
+		`)
+	})
+
+	// check that renaming works, we do not test every single route here, the name variable is used
+	// for each route, we just check the 5 basic ones. Marshalling and Unmarshalling is tested with
+	// this again too.
+	It("FindAll returns 200", func() {
+		req, err := http.NewRequest("GET", "/v1/food/sconeTastes", nil)
+		Expect(err).ToNot(HaveOccurred())
+		api.Handler().ServeHTTP(rec, req)
+		Expect(rec.Code).To(Equal(http.StatusOK))
+	})
+
+	It("FindOne", func() {
+		req, err := http.NewRequest("GET", "/v1/food/sconeTastes/12345", nil)
+		Expect(err).ToNot(HaveOccurred())
+		api.Handler().ServeHTTP(rec, req)
+		Expect(rec.Code).To(Equal(http.StatusOK))
+	})
+
+	It("Delete", func() {
+		req, err := http.NewRequest("DELETE", "/v1/food/sconeTastes/12345", nil)
+		Expect(err).ToNot(HaveOccurred())
+		api.Handler().ServeHTTP(rec, req)
+		Expect(rec.Code).To(Equal(http.StatusNoContent))
+	})
+
+	It("Create", func() {
+		req, err := http.NewRequest("POST", "/v1/food/sconeTastes", body)
+		Expect(err).ToNot(HaveOccurred())
+		api.Handler().ServeHTTP(rec, req)
+		// the response is always the one record returned by FindOne, the implementation does not
+		// check the ID here and returns something new ...
+		Expect(rec.Body.String()).To(MatchJSON(`
+		{
+			"data": {
+				"attributes": {
+					"taste": "smells awful"
+				},
+				"id": "newID",
+				"type": "Scone-tastes"
+			}
+		}
+		`))
+		Expect(rec.Code).To(Equal(http.StatusCreated))
+	})
+
+	It("Update", func() {
+		req, err := http.NewRequest("PATCH", "/v1/food/sconeTastes/blubb", body)
+		Expect(err).ToNot(HaveOccurred())
+		api.Handler().ServeHTTP(rec, req)
+		Expect(rec.Body.String()).To(Equal(""))
+		Expect(rec.Code).To(Equal(http.StatusNoContent))
+	})
+})

--- a/jsonapi/entity_namer.go
+++ b/jsonapi/entity_namer.go
@@ -7,3 +7,11 @@ package jsonapi
 type EntityNamer interface {
 	GetName() string
 }
+
+// The EntityPather interface can be optionally implemented to directly return the
+// path for the resource to be used for routing to the resource.
+// The resulting base URL will take the form `/{apiPrefix}/{path}/{id}`
+// Note: By default the path is guessed from the struct name.
+type EntityPather interface {
+	GetPath() string
+}


### PR DESCRIPTION
With this change it will be possible to customize the resource specific portion of the URL on a per resource type basis. This is useful in the following cases:
- Using a different casing format for the URL vs the resource type name
- When the prefix info is also included in the resource type name