### PR TITLE
Expose the original http request context

### DIFF
--- a/api.go
+++ b/api.go
@@ -256,10 +256,10 @@ func (api *API) addResource(prototype jsonapi.MarshalIdentifier, source interfac
 		baseURL = "/" + prefix + baseURL
 	}
 
-	api.router.Handle("OPTIONS", baseURL, func(w http.ResponseWriter, r *http.Request, _ map[string]string, context map[string]interface{}) {
+	api.router.Handle("OPTIONS", baseURL, func(w http.ResponseWriter, r *http.Request, params map[string]string, context map[string]interface{}) {
 		c := api.contextPool.Get().(APIContexter)
-		c.Reset()
-
+		c.Reset(r.Context())
+		c.Set("PathParams", params)
 		for key, val := range context {
 			c.Set(key, val)
 		}
@@ -270,10 +270,11 @@ func (api *API) addResource(prototype jsonapi.MarshalIdentifier, source interfac
 		api.contextPool.Put(c)
 	})
 
-	api.router.Handle("GET", baseURL, func(w http.ResponseWriter, r *http.Request, _ map[string]string, context map[string]interface{}) {
+	api.router.Handle("GET", baseURL, func(w http.ResponseWriter, r *http.Request, params map[string]string, context map[string]interface{}) {
 		info := requestInfo(r, api)
 		c := api.contextPool.Get().(APIContexter)
-		c.Reset()
+		c.Reset(r.Context())
+		c.Set("PathParams", params)
 
 		for key, val := range context {
 			c.Set(key, val)
@@ -289,9 +290,10 @@ func (api *API) addResource(prototype jsonapi.MarshalIdentifier, source interfac
 	})
 
 	if _, ok := source.(ResourceGetter); ok {
-		api.router.Handle("OPTIONS", baseURL+"/:id", func(w http.ResponseWriter, r *http.Request, _ map[string]string, context map[string]interface{}) {
+		api.router.Handle("OPTIONS", baseURL+"/:id", func(w http.ResponseWriter, r *http.Request, params map[string]string, context map[string]interface{}) {
 			c := api.contextPool.Get().(APIContexter)
-			c.Reset()
+			c.Reset(r.Context())
+			c.Set("PathParams", params)
 
 			for key, val := range context {
 				c.Set(key, val)
@@ -306,7 +308,8 @@ func (api *API) addResource(prototype jsonapi.MarshalIdentifier, source interfac
 		api.router.Handle("GET", baseURL+"/:id", func(w http.ResponseWriter, r *http.Request, params map[string]string, context map[string]interface{}) {
 			info := requestInfo(r, api)
 			c := api.contextPool.Get().(APIContexter)
-			c.Reset()
+			c.Reset(r.Context())
+			c.Set("PathParams", params)
 
 			for key, val := range context {
 				c.Set(key, val)
@@ -330,7 +333,8 @@ func (api *API) addResource(prototype jsonapi.MarshalIdentifier, source interfac
 				return func(w http.ResponseWriter, r *http.Request, params map[string]string, context map[string]interface{}) {
 					info := requestInfo(r, api)
 					c := api.contextPool.Get().(APIContexter)
-					c.Reset()
+					c.Reset(r.Context())
+					c.Set("PathParams", params)
 
 					for key, val := range context {
 						c.Set(key, val)
@@ -349,7 +353,8 @@ func (api *API) addResource(prototype jsonapi.MarshalIdentifier, source interfac
 				return func(w http.ResponseWriter, r *http.Request, params map[string]string, context map[string]interface{}) {
 					info := requestInfo(r, api)
 					c := api.contextPool.Get().(APIContexter)
-					c.Reset()
+					c.Reset(r.Context())
+					c.Set("PathParams", params)
 
 					for key, val := range context {
 						c.Set(key, val)
@@ -367,7 +372,8 @@ func (api *API) addResource(prototype jsonapi.MarshalIdentifier, source interfac
 			api.router.Handle("PATCH", baseURL+"/:id/relationships/"+relation.Name, func(relation jsonapi.Reference) routing.HandlerFunc {
 				return func(w http.ResponseWriter, r *http.Request, params map[string]string, context map[string]interface{}) {
 					c := api.contextPool.Get().(APIContexter)
-					c.Reset()
+					c.Reset(r.Context())
+					c.Set("PathParams", params)
 
 					for key, val := range context {
 						c.Set(key, val)
@@ -387,7 +393,8 @@ func (api *API) addResource(prototype jsonapi.MarshalIdentifier, source interfac
 				api.router.Handle("POST", baseURL+"/:id/relationships/"+relation.Name, func(relation jsonapi.Reference) routing.HandlerFunc {
 					return func(w http.ResponseWriter, r *http.Request, params map[string]string, context map[string]interface{}) {
 						c := api.contextPool.Get().(APIContexter)
-						c.Reset()
+						c.Reset(r.Context())
+						c.Set("PathParams", params)
 
 						for key, val := range context {
 							c.Set(key, val)
@@ -405,7 +412,8 @@ func (api *API) addResource(prototype jsonapi.MarshalIdentifier, source interfac
 				api.router.Handle("DELETE", baseURL+"/:id/relationships/"+relation.Name, func(relation jsonapi.Reference) routing.HandlerFunc {
 					return func(w http.ResponseWriter, r *http.Request, params map[string]string, context map[string]interface{}) {
 						c := api.contextPool.Get().(APIContexter)
-						c.Reset()
+						c.Reset(r.Context())
+						c.Set("PathParams", params)
 
 						for key, val := range context {
 							c.Set(key, val)
@@ -427,7 +435,8 @@ func (api *API) addResource(prototype jsonapi.MarshalIdentifier, source interfac
 		api.router.Handle("POST", baseURL, func(w http.ResponseWriter, r *http.Request, params map[string]string, context map[string]interface{}) {
 			info := requestInfo(r, api)
 			c := api.contextPool.Get().(APIContexter)
-			c.Reset()
+			c.Reset(r.Context())
+			c.Set("PathParams", params)
 
 			for key, val := range context {
 				c.Set(key, val)
@@ -445,7 +454,8 @@ func (api *API) addResource(prototype jsonapi.MarshalIdentifier, source interfac
 	if _, ok := source.(ResourceDeleter); ok {
 		api.router.Handle("DELETE", baseURL+"/:id", func(w http.ResponseWriter, r *http.Request, params map[string]string, context map[string]interface{}) {
 			c := api.contextPool.Get().(APIContexter)
-			c.Reset()
+			c.Reset(r.Context())
+			c.Set("PathParams", params)
 
 			for key, val := range context {
 				c.Set(key, val)
@@ -464,7 +474,8 @@ func (api *API) addResource(prototype jsonapi.MarshalIdentifier, source interfac
 		api.router.Handle("PATCH", baseURL+"/:id", func(w http.ResponseWriter, r *http.Request, params map[string]string, context map[string]interface{}) {
 			info := requestInfo(r, api)
 			c := api.contextPool.Get().(APIContexter)
-			c.Reset()
+			c.Reset(r.Context())
+			c.Set("PathParams", params)
 
 			for key, val := range context {
 				c.Set(key, val)

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/manyminds/api2go
 
+go 1.13
+
 require (
 	github.com/gedex/inflector v0.0.0-20170307190818-16278e9db813
 	github.com/gin-gonic/gin v1.4.0


### PR DESCRIPTION
Use the original http request context as the starting point for the internal context. This will allow prior middleware to pass data to our handlers instead of only the custom api2go middleware.

A custom context based on [gin](https://github.com/gin-gonic/gin/blob/master/context.go)'s context was added in [this PR](https://github.com/manyminds/api2go/pull/170). It however does not fully wrap the http request and response like gin's does so it not very useful. In the future I'll likely merge the this struct with api2go's request struct based on the way it is getting used. 

We can also likely remove the context pool. Based on [this keynote](https://blog.golang.org/ismmkeynote) from a contributor to Go's garbage collector and [this review](https://medium.com/a-journey-with-go/go-understand-the-design-of-sync-pool-2dde3024e277) of sync.pool I suspect it is not actually speeding things up at all. 